### PR TITLE
ci: Auto-cut a Release when tagged

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -3,6 +3,7 @@ name: Bazel build
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1
 
+# yamllint disable-line rule:truthy
 on: [push]
 
 jobs:

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,5 +1,6 @@
 name: Conventional Commits
 
+# yamllint disable-line rule:truthy
 on:
   pull_request:
     branches: [ master ]

--- a/.github/workflows/release-if-tagged.yaml
+++ b/.github/workflows/release-if-tagged.yaml
@@ -1,0 +1,31 @@
+name: Create Release on New Tag
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Create changelog text
+        id: changelog
+        uses: loopwerk/tag-changelog@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exclude_types: other,typo
+
+      - name: Create release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.changelog.outputs.changes }}

--- a/.github/workflows/release-if-tagged.yaml
+++ b/.github/workflows/release-if-tagged.yaml
@@ -1,31 +1,36 @@
+---
 name: Create Release on New Tag
 
 # yamllint disable-line rule:truthy
 on:
   push:
     tags:
-      - '*'
+      - "v*"
 
 jobs:
   create-release:
+    name: "Create Release"
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Create changelog text
-        id: changelog
-        uses: loopwerk/tag-changelog@v1
+      - run: mkdir -p ${HOME}/.cache/bazel
+      - name: Mount bazel cache  # Optional
+        uses: actions/cache@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          exclude_types: other,typo
+          path: "${HOME}/.cache/bazel"
+          key: bazel
 
-      - name: Create release
-        uses: actions/create-release@v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: bazel build //...
+
+      - name: Create release with Changelog Text
+        uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          tag_name: ${{ github.ref }}
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ${{ github.ref }}
+          title: Release ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          body: ${{ steps.changelog.outputs.changes }}
+          files: |
+            bazel-bin/chickenandbazel.pkg

--- a/.github/workflows/tag-if-release-worthy.yaml
+++ b/.github/workflows/tag-if-release-worthy.yaml
@@ -3,6 +3,7 @@ name: Release-Worthiness
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1
 
+# yamllint disable-line rule:truthy
 on:
   pull_request:
     types:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@//lib:pkgbuild.bzl", "pkgbuild_tars")
 
@@ -30,4 +31,12 @@ pkgbuild_tars(
     identifier = "nu.old.chickenandbazel",
     tars = [":binaries"],
     version = VERSION,
+)
+
+copy_file(
+    name = "dist_pkg",
+    src = ":pkg",
+    out = ".distrib/chickenandbazel.pkg",
+    allow_symlink = True,
+    is_executable = False,
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,15 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "bazel_skylib",
+    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+    ],
+)
+
+http_archive(
     name = "rules_pkg",
     sha256 = "8c20f74bca25d2d442b327ae26768c02cf3c99e93fad0381f32be9aab1967675",
     urls = [
@@ -18,6 +27,10 @@ http_archive(
     strip_prefix = "rules_python-0.18.1",
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.18.1/rules_python-0.18.1.tar.gz",
 )
+
+# Unneeded until using unittests
+#load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+#bazel_skylib_workspace()
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 

--- a/toolchains/git-town/deps.bzl
+++ b/toolchains/git-town/deps.bzl
@@ -26,4 +26,4 @@ def deps():
     p = preferred_release()
     for a in p:
         name = a.replace("-", "_")
-        http_archive(name = name, build_file_content="exports_files(['git-town'])", urls = [p[a]["url"]], sha256 = p[a]["sha256"])
+        http_archive(name = name, build_file_content = "exports_files(['git-town'])", urls = [p[a]["url"]], sha256 = p[a]["sha256"])


### PR DESCRIPTION
This PR extends #24 to actually create a Release.

#24 tags a commit if there's sufficient backlog to warrant a release; triggered on creation of a new tag, this PR carries a workflow that calculates the delta from the current and previous tags, and uses that to create a new Release using the GH API.

This should close out the ability to automatically release updates when features are added and when renovate pushes dependency updates.