### PR TITLE
fix: explicitly push tags upstream

### DIFF
--- a/lib/python/release-worthy.py
+++ b/lib/python/release-worthy.py
@@ -238,7 +238,7 @@ def main():
                 message="Backlog sufficient to post automatic release",
             )
             print(f"Tagged {new_version} per {release}")
-            repo.remote.origin.push(new_version)
+            repo.remote().push(new_version)
             print(f"Pushed {new_version} to {repo.remote.origin}")
         else:
             print(f"Skipped (dryrun) tagging {new_version} per {release}")


### PR DESCRIPTION
Iterate-in-public, test-in-prod: maybe this will satisfy the late-bound dunno-if-it-will-work python interpreted language.  If only we had languages that would validate all symbols before shipping.