### PR TITLE
ci: Fix bazel cache key

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -2,6 +2,7 @@ name: Bazel build
 
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1
+  TEST_TMPDIR: /tmp/.bazel
 
 # yamllint disable-line rule:truthy
 on: [push]
@@ -17,11 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # action runners have bazelisk: - uses: bazelbuild/setup-bazelisk@v2
-      - run: mkdir -p ${HOME}/.cache/bazel
+      - run: mkdir -p "${TEST_TMPDIR}"
+      - run: env | sort
       - name: Mount bazel cache  # Optional
         uses: actions/cache@v3
         with:
-          path: "${HOME}/.cache/bazel"
-          key: bazel
+          # needs to be an absolute path, not a variable; I've made it match TEST_TMPDIR above
+          path: /tmp/
+          key: .bazel
       - run: bazel build //...
       - run: bazel test //...

--- a/.github/workflows/release-if-tagged.yaml
+++ b/.github/workflows/release-if-tagged.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+env:
+  TEST_TMPDIR: /tmp/.bazel
+
 jobs:
   create-release:
     name: "Create Release"
@@ -16,23 +19,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - run: mkdir -p ${HOME}/.cache/bazel
       - name: Mount bazel cache  # Optional
         uses: actions/cache@v3
         with:
-          path: "${HOME}/.cache/bazel"
-          key: bazel
+          path: "/tmp/"
+          key: .bazel
 
+      - run: |
+          echo "GITHUB_REF ${GITHUB_REF#refs/*/}"
+          echo "GITHUB.REF ${{ github.ref }}"
       - run: bazel build //...
 
-      - name: Create release with Changelog Text
-        uses: "marvinpinto/action-automatic-releases@latest"
-        env:
-          RELEASE_TAG: ${{ github.ref }}
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ github.ref }}
-          title: Release ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          files: |
-            bazel-bin/chickenandbazel.pkg
+#      - name: Create release with Changelog Text
+#        uses: "marvinpinto/action-automatic-releases@latest"
+#        env:
+#          RELEASE_TAG: ${{ github.ref }}
+#        with:
+#          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+#          automatic_release_tag: ${{ github.ref }}
+#          title: Release ${{ github.ref }}
+#          release_name: Release ${{ github.ref }}
+#          files: |
+#            bazel-bin/chickenandbazel.pkg


### PR DESCRIPTION
We never seem to get a cache hit; I don't think the key is lining up with what's actually being created during a bazel run.

Iterating on this PR to determine a better key and/or path.