### PR TITLE
ci: Stamp binaries with version based on tag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --stamp --workspace_status_command=./lib/bazel/workplace_status.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,13 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "2518c757715d4f5fc7cc7e0a68742dd1155eaafc78fb9196b8a18e13a738cea2",
+    strip_prefix = "bazel-lib-1.28.0",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz",
+)
+
+http_archive(
     name = "bazel_skylib",
     sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
     urls = [
@@ -35,6 +42,10 @@ http_archive(
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+
+aspect_bazel_lib_dependencies()
 
 ###
 # Tools bundled

--- a/lib/bazel/workplace_status.sh
+++ b/lib/bazel/workplace_status.sh
@@ -1,0 +1,1 @@
+echo "VERSION $(git describe --tags --abbrev=0)"

--- a/lib/pkgbuild_tars.sh.tpl
+++ b/lib/pkgbuild_tars.sh.tpl
@@ -15,6 +15,8 @@
 
 TMPDIR=`mktemp -d -t pkgbuild` || { echo "$0: Cannot create working (root) directory; aborting"; exit 1; }
 
+eval $(cat /dev/null {STATUS_FILE_STABLE} {STATUS_FILE_VOLATILE} | grep ^VERSION | sed -e 's/ v/=/g')
+
 # extract all tarchives to the designated root
 for t in {TARS} ; do
        tar -C "${TMPDIR}" -xf ${t}
@@ -26,6 +28,6 @@ done
     --identifier "{IDENTIFIER}" \
     {OPT_COMPONENT_PLIST} \
     {OPT_SCRIPTS_DIR} \
-    --version "{VERSION}" \
+    --version "${VERSION:-{ATTR_VERSION}}" \
     --root "${TMPDIR}" \
     "{OUTPUT}"


### PR DESCRIPTION
Use Aspect's stamping lib to stamp a version from a tag through to the built pkg