### PR TITLE
chore: update precommit

### DIFF
--- a/.github/renovate-regex.json
+++ b/.github/renovate-regex.json
@@ -1,10 +1,10 @@
 {
-  "bazel_watcher_darwin_arm64": {
+  "ibazel_darwin_arm64": {
     "renovate_datasource": "github-release-attachments",
     "renovate_depname": "bazelbuild/bazel-watcher",
     "renovate_versioning": "semver",
-    "sha256": "c2da75cbab7a4b2b97ba534653bb12e4dd731157bb1c9d660f79df3b330a7239",
-    "version": "v0.25.3"
+    "sha256": "e4d5e04a2a0e4dda21350ffe26623469a85ab8786570aea962b058a954dcd3f1",
+    "version": "v0.25.2"
   },
   "bazelisk_darwin_amd64": {
     "renovate_datasource": "github-release-attachments",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
 ---
 repos:
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.26.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
         args: [
@@ -16,13 +16,8 @@ repos:
           '{extends: relaxed, rules: {line-length: {max: 320}}}'
         ]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.20.0
+    rev: 0.31.0
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
       - id: check-renovate
-  - repo: https://github.com/warchant/pre-commit-buildifier
-    rev: 0.0.2
-    hooks:
-    -   id: buildifier
-        args: ['--version', "5.1.0", '-mode=fix']


### PR DESCRIPTION
- Manual `pre-commit autoupdate`
- yep, back-stepping a release metadata to trigger update