### PR TITLE
chore: add datasources and sha256 for git-town, ibazel

### DIFF
--- a/.github/renovate-regex.json
+++ b/.github/renovate-regex.json
@@ -1,11 +1,4 @@
 {
-  "ibazel_darwin_arm64": {
-    "renovate_datasource": "github-release-attachments",
-    "renovate_depname": "bazelbuild/bazel-watcher",
-    "renovate_versioning": "semver",
-    "sha256": "e4d5e04a2a0e4dda21350ffe26623469a85ab8786570aea962b058a954dcd3f1",
-    "version": "v0.25.2"
-  },
   "bazelisk_darwin_amd64": {
     "renovate_datasource": "github-release-attachments",
     "renovate_depname": "bazelbuild/bazelisk",
@@ -19,5 +12,26 @@
     "renovate_versioning": "semver",
     "sha256": "b13dd89c6ecd90944ca3539f5a2c715a18f69b7458878c471a902a8e482ceb4b",
     "version": "v1.25.0"
+  },
+  "gittown_darwin_amd64": {
+    "renovate_datasource": "github-release-attachments",
+    "renovate_depname": "git-town/git-town",
+    "renovate_versioning": "semver",
+    "sha256": "698feca01936082d00770425937f7260ccaf2522d0a043cf777592ff632adbfd",
+    "version": "v17.2.0"
+  },
+  "gittown_darwin_arm64": {
+    "renovate_datasource": "github-release-attachments",
+    "renovate_depname": "git-town/git-town",
+    "renovate_versioning": "semver",
+    "sha256": "1071f1915ad1c545e1ac8d33b573cee0819cf857dbf5a6e307e7f7f284dc8183",
+    "version": "v17.2.0"
+  },
+  "ibazel_darwin_arm64": {
+    "renovate_datasource": "github-release-attachments",
+    "renovate_depname": "bazelbuild/bazel-watcher",
+    "renovate_versioning": "semver",
+    "sha256": "e4d5e04a2a0e4dda21350ffe26623469a85ab8786570aea962b058a954dcd3f1",
+    "version": "v0.25.2"
   }
 }


### PR DESCRIPTION
In order to bring more managed sha256 and versions, add datasources for `ibazel`, `git-town`