### PR TITLE
feat: provide a convenience target that can build-and-install the pkg

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -48,3 +48,11 @@ alias(
   name = "multitool",
   actual = "//toolchains/multitool",
 )
+
+genrule(
+  name = "sudoinstall",
+  cmd = "echo 'sudo installer -target / -pkg $<' > $@",
+  executable = True,
+  srcs = [ ":pkg" ],
+  outs = [ "install.bash" ],
+)


### PR DESCRIPTION
This PR allows:
 - `bazel build //:sudoinstall` to build the script
 - `bazel run //:sudoinstall` to un the script that sudo-installs the PKG

`bazel run sudoinstall` works fine as well.