### PR TITLE
feat: provide multitool binary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,3 +43,8 @@ copy_file(
     allow_symlink = True,
     is_executable = False,
 )
+
+alias(
+  name = "multitool",
+  actual = "//toolchains/multitool",
+)

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -49,6 +49,26 @@
       }
     ]
   },
+  "multitool": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/theoremlp/multitool/releases/download/v0.9.0/multitool-aarch64-apple-darwin.tar.xz",
+        "file": "multitool-aarch64-apple-darwin/multitool",
+        "sha256": "8f5e0cd033b0fcc128c762f8d527110433523da378619cecf40e91c1df5c0686",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/theoremlp/multitool/releases/download/v0.9.0/multitool-x86_64-apple-darwin.tar.xz",
+        "file": "multitool-x86_64-apple-darwin/multitool",
+        "sha256": "abde3bbbd49a09d33048e1f55cc9a8aa5dd61a13493a0b1bd5ffc2c56e5bf837",
+        "os": "macos",
+        "cpu": "x86_64"
+      }
+    ]
+  },
   "nomad": {
     "binaries": [
       {

--- a/toolchains/multitool/BUILD.bazel
+++ b/toolchains/multitool/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//lib:lipo.bzl", "lipo_check", "lipo_create")
+
+lipo_check(binary = ":multitool")
+
+lipo_create(
+    name = "lipo",
+    srcs = [
+        "@@rules_multitool++multitool+multitool.multitool.macos_arm64//tools/multitool:macos_arm64_executable",
+        "@@rules_multitool++multitool+multitool.multitool.macos_x86_64//tools/multitool:macos_x86_64_executable",
+    ],
+    out = "multitool",
+)


### PR DESCRIPTION
In order to facilitate manual maintenance, this PR adds the multitool` binary but does not deliver as part of the `:pkg`.  Rather, it allows:

`bazel run multitool -- --lockfile ./multitool.lock.json update`