### PR TITLE
feat: provide age-keygen binary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,6 +15,7 @@ pkg_tar(
     srcs = [
         "//scripts:check-installs.sh",
         "//toolchains/age:lipo",
+        "//toolchains/age-keygen:lipo",
         "//toolchains/bazelisk:lipo",
         "//toolchains/git-town:lipo",
         "//toolchains/ibazel:lipo",

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -20,6 +20,26 @@
       }
     ]
   },
+  "age-keygen": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/FiloSottile/age/releases/download/v1.2.1/age-v1.2.1-darwin-arm64.tar.gz",
+        "file": "age/age-keygen",
+        "sha256": "cf79875bd5970dc2dac60c87fa50cee1ff1f9a41b0eb273f65e174aff37c367a",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/FiloSottile/age/releases/download/v1.2.1/age-v1.2.1-darwin-amd64.tar.gz",
+        "file": "age/age-keygen",
+        "sha256": "424e1d64438a730626540b2e01e98d132a64214442ca9465b3e82336d12e633e",
+        "os": "macos",
+        "cpu": "x86_64"
+      }
+    ]
+  },
   "bazelisk": {
     "binaries": [
       {

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -109,6 +109,24 @@
       }
     ]
   },
+  "sops": {
+    "binaries": [
+      {
+        "kind": "file",
+        "url": "https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.darwin.arm64",
+        "sha256": "e197a40869ece97400c2ca08f195c04d39945158558b2d4203791b24022fc467",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.darwin.amd64",
+        "sha256": "77b2fb62aa16d69f2549ed72151d467174d3d961800e89d7a08af34edf151009",
+        "os": "macos",
+        "cpu": "x86_64"
+      }
+    ]
+  },
   "terraform": {
     "binaries": [
       {

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -109,24 +109,6 @@
       }
     ]
   },
-  "sops": {
-    "binaries": [
-      {
-        "kind": "file",
-        "url": "https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.darwin.arm64",
-        "sha256": "e197a40869ece97400c2ca08f195c04d39945158558b2d4203791b24022fc467",
-        "os": "macos",
-        "cpu": "arm64"
-      },
-      {
-        "kind": "file",
-        "url": "https://github.com/getsops/sops/releases/download/v3.10.1/sops-v3.10.1.darwin.amd64",
-        "sha256": "77b2fb62aa16d69f2549ed72151d467174d3d961800e89d7a08af34edf151009",
-        "os": "macos",
-        "cpu": "x86_64"
-      }
-    ]
-  },
   "terraform": {
     "binaries": [
       {

--- a/toolchains/age-keygen/BUILD.bazel
+++ b/toolchains/age-keygen/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//lib:lipo.bzl", "lipo_check", "lipo_create")
+
+lipo_check(binary = ":age-keygen")
+
+lipo_create(
+    name = "lipo",
+    srcs = [
+        "@@rules_multitool++multitool+multitool.age-keygen.macos_arm64//tools/age-keygen:macos_arm64_executable",
+        "@@rules_multitool++multitool+multitool.age-keygen.macos_x86_64//tools/age-keygen:macos_x86_64_executable",
+    ],
+    out = "age-keygen",
+)


### PR DESCRIPTION
When #126 provided `sops` and `age`, I missed that `age-keygen` was necessary.  This PR corrects