### PR TITLE
fix: ibazel shoud lipo both macos arch

### DIFF
--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -86,6 +86,13 @@
         "sha256": "e4d5e04a2a0e4dda21350ffe26623469a85ab8786570aea962b058a954dcd3f1",
         "os": "macos",
         "cpu": "arm64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/bazelbuild/bazel-watcher/releases/download/v0.25.1/ibazel_darwin_amd64",
+        "sha256": "81b170f5911fafef837da10addacb923da759334b0bad9b2e4cc14d0643dc15c",
+        "os": "macos",
+        "cpu": "x86_64"
       }
     ]
   },

--- a/toolchains/ibazel/BUILD.bazel
+++ b/toolchains/ibazel/BUILD.bazel
@@ -6,7 +6,7 @@ lipo_create(
     name = "lipo",
     srcs = [
         "@@rules_multitool++multitool+multitool.ibazel.macos_arm64//tools/ibazel:macos_arm64_executable",
-        #"@@rules_multitool++multitool+multitool.ibazel.macos_x86_64//tools/ibazel:macos_x86_64_executable",
+        "@@rules_multitool++multitool+multitool.ibazel.macos_x86_64//tools/ibazel:macos_x86_64_executable",
     ],
     out = "ibazel",
 )


### PR DESCRIPTION
When #104 bzlmodified the build, #101 had only provided `arm64` version and checksum for `ibazel` because **that's all there was**.   The 0.25.2 and 0.25.3 releases include no binary for macOS/x86.

To provide **something**, this binary brings in `ibazel-0.25.1` for macOS/x86_64.