### PR TITLE
feat: provide gh-poi binary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,6 +17,7 @@ pkg_tar(
         "//toolchains/age:lipo",
         "//toolchains/age-keygen:lipo",
         "//toolchains/bazelisk:lipo",
+        "//toolchains/gh-poi:lipo",
         "//toolchains/git-lfs:lipo",
         "//toolchains/git-town:lipo",
         "//toolchains/ibazel:lipo",

--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -58,6 +58,24 @@
       }
     ]
   },
+  "gh-poi": {
+    "binaries": [
+      {
+        "kind": "file",
+        "url": "https://github.com/seachicken/gh-poi/releases/download/v0.18.3/darwin-arm64",
+        "sha256": "f0e05131ffca6e21827233c736ddfb1dbfc287f2f071df98dc7f90b73376dc6f",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "file",
+        "url": "https://github.com/seachicken/gh-poi/releases/download/v0.18.3/darwin-amd64",
+        "sha256": "5b55daf0906a272f099442631c619a6ff44d9f77be36954ccfb344bfadf5b480",
+        "os": "macos",
+        "cpu": "x86_64"
+      }
+    ]
+  },
   "gitlfs": {
     "binaries": [
       {

--- a/toolchains/gh-poi/BUILD.bazel
+++ b/toolchains/gh-poi/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//lib:lipo.bzl", "lipo_check", "lipo_create")
+
+lipo_check(binary = ":gh-poi")
+
+lipo_create(
+    name = "lipo",
+    srcs = [
+        "@@rules_multitool++multitool+multitool.gh-poi.macos_arm64//tools/gh-poi:macos_arm64_executable",
+        "@@rules_multitool++multitool+multitool.gh-poi.macos_x86_64//tools/gh-poi:macos_x86_64_executable",
+    ],
+    out = "gh-poi",
+)


### PR DESCRIPTION
`gh-poi` gives us the `git poi` that does a better job of cleaning up the committed/merged branches