### PR TITLE
Fix: Explicit __init.py__ content

### DIFF
--- a/lib/python/BUILD.bazel
+++ b/lib/python/BUILD.bazel
@@ -1,12 +1,17 @@
 py_binary(
+    legacy_create_init = 0,
     name = "release-worthy",
-    srcs = ["release-worthy.py"],
+    srcs = [
+        "__init__.py",
+        "release-worthy.py",
+    ],
 )
 
 py_test(
+    legacy_create_init = 0,
     name = "weights_test",
-    srcs = ["weights_test.py"],
-    #deps = [
-    #    "//path/to/a/py/library",
-    #],
+    srcs = [
+        "__init__.py",
+        "weights_test.py",
+    ],
 )


### PR DESCRIPTION
Fixes this sort of warning (that was happening in the code I control; this example is external code in a dependency)

```
======================================================================
WARNING: Target @@rules_pkg+//pkg/private/tar:build_tar is using implicit __init__.py creation.
  This diabolic behavior is deprecated and will be disabled by default in a
  future release.
  See https://github.com/bazel-contrib/rules_python/issues/2945

  Ensure all __init__.py files are explicitly created and
  added to the srcs or deps of your targets.

  Disable implicit creation by setting:
    legacy_create_init = 0
  on the target, or globally by setting:
    --incompatible_default_to_explicit_init_py
======================================================================
```